### PR TITLE
Level 2 adjustments & git config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Set the default behavior, in lieu of the core.autocrlf client setting.
+* text=auto
+
+# PBT files for some reason use LF and should be checked-in and -out as such.
+# This appears to be behaviour related to Core's game engine.
+*.pbt text eol=lf
+
+# Plan B to resolve massive commits of *.pbt files: Declare them untouchable,
+# as binary files (even though they are clearly not ;)
+#*.png binary

--- a/Data/Tree/Tree.pbt
+++ b/Data/Tree/Tree.pbt
@@ -529,11 +529,12 @@ Objects {
   Name: "Level 2"
   Transform {
     Location {
-      X: -27890
-      Y: 44140
+      X: -14000
+      Y: 42250
       Z: 3500
     }
     Rotation {
+      Yaw: 180
     }
     Scale {
       X: 1


### PR DESCRIPTION
Spun level 2 around the proper way, moved it around a bit with respect to the terrain.   Added a .gitattributes file that will override client settings and ensure that .pbt files can use LF instead of CRLF for line endings:  This appears to be the way that the Core engine likes things.